### PR TITLE
MPI - Contempla fecha fallecimiento para calcular edad

### DIFF
--- a/src/lib/pipes/edad.pipe.ts
+++ b/src/lib/pipes/edad.pipe.ts
@@ -5,7 +5,7 @@ import * as moment from 'moment';
 // pure: false - Info: https://stackoverflow.com/questions/34456430/ngfor-doesnt-update-data-with-pipe-in-angular2
 export class EdadPipe implements PipeTransform {
     transform(value: any): any {
-        const fechaActual = moment();
+        const fechaLimite = value.fechaFallecimiento ? moment(value.fechaFallecimiento) : moment();
         let fechaNac: any;
         let difAnios: number;
         let difDias: number;
@@ -14,11 +14,11 @@ export class EdadPipe implements PipeTransform {
         let difMn: number;
 
         fechaNac = moment(value.fechaNacimiento, 'YYYY-MM-DD HH:mm:ss');
-        difDias = fechaActual.diff(fechaNac, 'd'); // Diferencia en días
+        difDias = fechaLimite.diff(fechaNac, 'd'); // Diferencia en días
         difAnios = Math.floor(difDias / 365.25);
         difMeses = Math.floor(difDias / 30.4375);
-        difHs = fechaActual.diff(fechaNac, 'h'); // Diferencia en horas
-        difMn = fechaActual.diff(fechaNac, 'm'); // Diferencia en minutos
+        difHs = fechaLimite.diff(fechaNac, 'h'); // Diferencia en horas
+        difMn = fechaLimite.diff(fechaNac, 'm'); // Diferencia en minutos
 
         if (difAnios !== 0) {
             return `${String(difAnios)} años`;


### PR DESCRIPTION
Requerimiento: https://proyectos.andes.gob.ar/browse/MPI-220

Desarrollo:
1. Se modifica la fecha tope/limite, a partir de la cual se calcula la edad, incluyendo la fecha de fallecimiento del paciente en caso de estar registrada

No requiere modificaciones en otros repositorios.